### PR TITLE
fix(instance): bind methods in constructor

### DIFF
--- a/src/__mocks__/mySafelySetInnerHTML.js
+++ b/src/__mocks__/mySafelySetInnerHTML.js
@@ -1,0 +1,5 @@
+import SafelySetInnerHTML from '../safelySetInnerHTML';
+
+const instance = new SafelySetInnerHTML();
+
+export default instance.transform;

--- a/src/__snapshots__/safelySetInnerHTML.test.js.snap
+++ b/src/__snapshots__/safelySetInnerHTML.test.js.snap
@@ -53,6 +53,15 @@ Array [
 ]
 `;
 
+exports[`SafelySetInnerHTML configuration file should render normally 1`] = `
+<p>
+  Configuration 
+  <strong>
+    File !
+  </strong>
+</p>
+`;
+
 exports[`SafelySetInnerHTML rendering process renders correctly 1`] = `
 <p>
   Hello 

--- a/src/safelySetInnerHTML.js
+++ b/src/safelySetInnerHTML.js
@@ -13,6 +13,9 @@ class SafelySetInnerHTML {
     this.cache = [];
 
     this.generateDom = this.generateDom.bind(this);
+    this.transform = this.transform.bind(this);
+    this.getCache = this.getCache.bind(this);
+    this.formatAttributes = this.formatAttributes.bind(this);
   }
 
   /**

--- a/src/safelySetInnerHTML.test.js
+++ b/src/safelySetInnerHTML.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import SafelySetInnerHTML from './safelySetInnerHTML';
+import mySafelySetInnerHTML from './__mocks__/mySafelySetInnerHTML';
 
 jest.spyOn(console, 'warn');
 
@@ -158,5 +159,14 @@ describe('SafelySetInnerHTML', () => {
       expect(cachedString.str).toEqual(cacheStr);
       expect(cacheInstance.generateDom).not.toHaveBeenCalled();
     });
+  });
+
+  describe('configuration file', () => {
+    it('should render normally', () => {
+      const dom = mySafelySetInnerHTML('Configuration <strong>File !</strong>');
+      const tree = renderer.create(<p>{dom}</p>).toJSON();
+
+      expect(tree).toMatchSnapshot();
+    })
   });
 });


### PR DESCRIPTION
all the public methods are automatically bound to the instance in its constructor
to prevent any oustide call exception

Fixes #5