### PR TITLE
feat(doc): install as prod dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ is not in this list, it won't be applied to the generated React element.
 Install the library with npm:
 
 ```sh
-$ npm install -D safely-set-inner-html
+$ npm install -P safely-set-inner-html
 ```
 
 ## :electric_plug: Usage


### PR DESCRIPTION
Updated `npm install`s flag in the documentation so that `safely-set-inner-html` is considered as a production dependency.